### PR TITLE
fix: asset url format being returned by the endpoint

### DIFF
--- a/src/controllers/handlers/resize-handler.ts
+++ b/src/controllers/handlers/resize-handler.ts
@@ -65,7 +65,7 @@ export async function resizeHandler(
     }
 
     return {
-      body: { asset: `${await config.getString('BUCKET_DOMAIN')}/${assetToUploadName}` }
+      body: { asset: `${await config.getString('BUCKET_DOMAIN')}${assetToUploadName}` }
     }
   } catch (error: any) {
     logger.error('Process failed', { error: error.message })


### PR DESCRIPTION
Fixes the URL of the asset being returned by the endpoint so it is well formatted (avoiding duplicate /)