### PR TITLE
chore: avoid triggering push-to-quay action on dependabot PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,8 @@ name: CI/CD on PR
 
 on:
   pull_request:
+    branches:
+      - '!dependabot/**'
 
 jobs:
   cd-dev:


### PR DESCRIPTION
Avoid triggering push-to-quay action on dependabot PRs.
Since we are not sharing our Quay keys with dependabot due to security concerns we need to avoid triggering this action on those kind of PRs.